### PR TITLE
DM-22565: Fix inconsistent names

### DIFF
--- a/python/lsst/ts/simactuators/path/path.py
+++ b/python/lsst/ts/simactuators/path/path.py
@@ -70,7 +70,7 @@ class Path:
         Parameters
         ----------
         tai : `float`
-            TAI time (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
+            TAI time (unix seconds, e.g. from lsst.ts.salobj.current_tai()).
 
         Returns
         -------

--- a/python/lsst/ts/simactuators/path/path_segment.py
+++ b/python/lsst/ts/simactuators/path/path_segment.py
@@ -52,7 +52,7 @@ class PathSegment:
     Parameters
     ----------
     tai : `float`
-        TAI time (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
+        TAI time (unix seconds, e.g. from lsst.ts.salobj.current_tai()).
     position : `float` at time ``tai`` (optional)
         Position (deg)
     velocity : `float` at time ``tai`` (optional)
@@ -79,14 +79,14 @@ class PathSegment:
         ----------
         start_tai : `float`
             TAI time for start path (unix seconds, e.g. from
-            lsst.ts.salobj.curr_tai()).
+            lsst.ts.salobj.current_tai()).
         start_position : `float` (optional)
             Position at ``start_tai`` (deg)
         start_velocity : `float` (optional)
             Velocity at ``start_tai`` (deg/sec)
         end_tai : `float`
             TAI time for end path (unix seconds,
-            e.g. from lsst.ts.salobj.curr_tai()).
+            e.g. from lsst.ts.salobj.current_tai()).
         end_position : `float` (optional)
             Position at ``end_tai`` (deg)
         end_velocity : `float` (optional)
@@ -119,7 +119,8 @@ class PathSegment:
         Parameters
         ----------
         end_tai : `float`
-            End time (TAI unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
+            End time (TAI unix seconds, e.g. from
+            lsst.ts.salobj.current_tai()).
 
         Returns
         -------
@@ -195,7 +196,7 @@ class PathSegment:
         Parameters
         ----------
         tai : `float`
-            Time (TAI unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
+            Time (TAI unix seconds, e.g. from lsst.ts.salobj.current_tai()).
 
         Returns
         -------

--- a/python/lsst/ts/simactuators/path/slew.py
+++ b/python/lsst/ts/simactuators/path/slew.py
@@ -40,7 +40,7 @@ def slew(tai, start_position, start_velocity, end_position,
     Parameters
     ----------
     tai : `float`
-        TAI time (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
+        TAI time (unix seconds, e.g. from lsst.ts.salobj.current_tai()).
     start_position : `float`
         Position of A at time ``tai`` (deg)
     start_velocity : `float`

--- a/python/lsst/ts/simactuators/path/slew.py
+++ b/python/lsst/ts/simactuators/path/slew.py
@@ -94,7 +94,7 @@ def slew(tai, start_position, start_velocity, end_position,
     (each of the first 3 segments is present only if its duration is nonzero,
     and the last is absent if the final segment already has zero acceleration):
 
-        segment   vel        accel          duration
+        segment   velocity        acceleration          duration
            1      start_velocity  start_accel    dt1
            2      vel_mid    0              dt2
            3      vel_mid    end_accel      dt3
@@ -135,7 +135,7 @@ def slew(tai, start_position, start_velocity, end_position,
         sign_end_velocityA = math.copysign(1.0, end_velocityA)
         sign_dpBAi = sign_end_velocityA
     else:
-        return path.Path(path_segment.PathSegment(tai=tai, pos=start_position, vel=start_velocity),
+        return path.Path(path_segment.PathSegment(tai=tai, position=start_position, velocity=start_velocity),
                          kind=path.Kind.Slewing)
 
     # Compute start_accel and accel3
@@ -158,7 +158,7 @@ def slew(tai, start_position, start_velocity, end_position,
     elif max_acceleration*abs(dpBAi)*SLEW_FUDGE <= half_end_velocityAsq:
         start_accel = -sign_dpBAi * max_acceleration
 
-    # A type 4 slew requires reducing accel. to obtain a solution.
+    # A type 4 slew requires reducing acceleration. to obtain a solution.
     else:
         # The equation for start_accel is sure to give
         # |start_accel| < max_acceleration
@@ -217,28 +217,37 @@ def slew(tai, start_position, start_velocity, end_position,
     segments = []
     if dt1 > 0:
         # There is a segment 1 with acceleration start_accel
-        segments.append(path_segment.PathSegment(tai=0, pos=start_position,
-                                                 vel=start_velocity, accel=start_accel))
+        segments.append(path_segment.PathSegment(tai=0, position=start_position,
+                                                 velocity=start_velocity,
+                                                 acceleration=start_accel))
         segment2 = segments[-1].at(dt1)
     else:
-        segment2 = path_segment.PathSegment(tai=segment2.tai, pos=start_position, vel=start_velocity)
+        segment2 = path_segment.PathSegment(tai=segment2.tai,
+                                            position=start_position,
+                                            velocity=start_velocity)
     if dt2 > 0:
         # There is a segment 2 with no acceleration
-        segments.append(path_segment.PathSegment(tai=segment2.tai, pos=segment2.pos, vel=segment2.vel))
+        segments.append(path_segment.PathSegment(tai=segment2.tai,
+                                                 position=segment2.position,
+                                                 velocity=segment2.velocity))
         segment3 = segments[-1].at(segment2.tai + dt2)
     else:
         segment3 = segment2
     if dt3 > 0:
         # There is a segment 3 with acceleration accel3
-        segments.append(path_segment.PathSegment(tai=segment3.tai, pos=segment3.pos,
-                                                 vel=segment3.vel, accel=accel3))
+        segments.append(path_segment.PathSegment(tai=segment3.tai,
+                                                 position=segment3.position,
+                                                 velocity=segment3.velocity,
+                                                 acceleration=accel3))
         segment4 = segments[-1].at(segment3.tai + dt3)
     else:
         segment4 = segment3
-    if segments[-1].accel != 0:
+    if segments[-1].acceleration != 0:
         # If the last PathSegment has non-zero acceleraton then append
         # a segment with zero acceleration.
-        segments.append(path_segment.PathSegment(tai=segment4.tai, pos=segment4.pos, vel=segment4.vel))
+        segments.append(path_segment.PathSegment(tai=segment4.tai,
+                                                 position=segment4.position,
+                                                 velocity=segment4.velocity))
     for segment in segments:
         segment.tai += tai
 

--- a/python/lsst/ts/simactuators/path/slew.py
+++ b/python/lsst/ts/simactuators/path/slew.py
@@ -222,7 +222,7 @@ def slew(tai, start_position, start_velocity, end_position,
                                                  acceleration=start_accel))
         segment2 = segments[-1].at(dt1)
     else:
-        segment2 = path_segment.PathSegment(tai=segment2.tai,
+        segment2 = path_segment.PathSegment(tai=0,
                                             position=start_position,
                                             velocity=start_velocity)
     if dt2 > 0:

--- a/python/lsst/ts/simactuators/path/stop.py
+++ b/python/lsst/ts/simactuators/path/stop.py
@@ -34,7 +34,7 @@ def stop(tai, position, velocity, max_acceleration):
     Parameters
     ----------
     tai : `float`
-        TAI time (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
+        TAI time (unix seconds, e.g. from lsst.ts.salobj.current_tai()).
     position : `float`
         Position at time ``tai`` (deg)
     velocity : `float`

--- a/python/lsst/ts/simactuators/path/stop.py
+++ b/python/lsst/ts/simactuators/path/stop.py
@@ -27,7 +27,7 @@ from . import path_segment
 from . import path
 
 
-def stop(tai, pos, vel, max_acceleration):
+def stop(tai, position, velocity, max_acceleration):
     """Compute a path to stop as quickly as possible,
     starting from a path of constant velocity.
 
@@ -35,9 +35,9 @@ def stop(tai, pos, vel, max_acceleration):
     ----------
     tai : `float`
         TAI time (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
-    pos : `float`
+    position : `float`
         Position at time ``tai`` (deg)
-    vel : `float`
+    velocity : `float`
         Velocity at time ``tai`` (deg/sec)
     max_acceleration : `float`
         Maximum allowed acceleration (deg/sec^2)
@@ -56,8 +56,8 @@ def stop(tai, pos, vel, max_acceleration):
     if max_acceleration <= 0.0:
         raise ValueError(f"max_acceleration={max_acceleration} < 0")
 
-    if vel == 0:
-        return path.Path(path_segment.PathSegment(tai=tai, pos=pos),
+    if velocity == 0:
+        return path.Path(path_segment.PathSegment(tai=tai, position=position),
                          kind=path.Kind.Stopped)
 
     segments = []
@@ -65,14 +65,14 @@ def stop(tai, pos, vel, max_acceleration):
     # have poor accuracy, so to improve accuracy
     # compute the path segments using tai = 0
     # then offset all the times before returning the path
-    dt = abs(vel)/max_acceleration
-    accel = -math.copysign(max_acceleration, vel)
-    p1 = pos + dt*(vel + dt*0.5*accel)
-    segments.append(path_segment.PathSegment(tai=0, pos=pos,
-                                             vel=vel, accel=accel))
-    segments.append(path_segment.PathSegment(tai=dt, pos=p1, vel=0))
+    dt = abs(velocity)/max_acceleration
+    acceleration = -math.copysign(max_acceleration, velocity)
+    p1 = position + dt*(velocity + dt*0.5*acceleration)
+    segments.append(path_segment.PathSegment(tai=0, position=position,
+                                             velocity=velocity, acceleration=acceleration))
+    segments.append(path_segment.PathSegment(tai=dt, position=p1, velocity=0))
 
-    for tpvaj in segments:
-        tpvaj.tai += tai
+    for segment in segments:
+        segment.tai += tai
 
     return path.Path(*segments, kind=path.Kind.Stopping)

--- a/python/lsst/ts/simactuators/point_to_point_actuator.py
+++ b/python/lsst/ts/simactuators/point_to_point_actuator.py
@@ -34,7 +34,7 @@ class PointToPointActuator:
         Minimum allowed position.
     max_position : `float`
         Maximum allowed position.
-    pos : `float`
+    start_position : `float`
         Initial position.
     speed : `float`
         Speed of motion.
@@ -44,22 +44,22 @@ class PointToPointActuator:
     ValueError
         If ``speed <= 0``,
         ``min_position >= max_position``,
-        or ``pos`` not in range ``[min_position, max_position]``.
+        or ``start_position`` not in range ``[min_position, max_position]``.
     """
-    def __init__(self, min_position, max_position, pos, speed):
+    def __init__(self, min_position, max_position, start_position, speed):
         if speed <= 0:
             raise ValueError(f"speed={speed} must be positive")
         if min_position >= max_position:
             raise ValueError(f"min_position={min_position} must be < max_position={max_position}")
-        if not min_position <= pos <= max_position:
-            raise ValueError(f"pos={pos} must be in range "
+        if not min_position <= start_position <= max_position:
+            raise ValueError(f"start_position={start_position} must be in range "
                              f"[{min_position}, {max_position}]")
 
         self.min_position = min_position
         self.max_position = max_position
         self.speed = speed
-        self._start_position = pos
-        self._end_position = pos
+        self._start_position = start_position
+        self._end_position = start_position
         # End time of move, or 0 if not moving.
         self._end_time = 0
 
@@ -75,18 +75,18 @@ class PointToPointActuator:
         """
         return self._end_position
 
-    def set_position(self, pos):
+    def set_position(self, position):
         """Set a new desired position.
 
         Raises
         ------
         ValueError
-            If pos < self.min_position or > self.max_position.
+            If position < self.min_position or > self.max_position.
         """
-        if pos < self.min_position or pos > self.max_position:
-            raise ValueError(f"pos={pos} not in range [{self.min_position}, {self.max_position}]")
+        if position < self.min_position or position > self.max_position:
+            raise ValueError(f"position={position} not in range [{self.min_position}, {self.max_position}]")
         self._start_position = self.current_position
-        self._end_position = pos
+        self._end_position = position
         dtime = abs(self.end_position - self.start_position) / self.speed
         self._end_time = time.monotonic() + dtime
 

--- a/python/lsst/ts/simactuators/point_to_point_actuator.py
+++ b/python/lsst/ts/simactuators/point_to_point_actuator.py
@@ -87,7 +87,7 @@ class PointToPointActuator:
             raise ValueError(f"position={position} not in range [{self.min_position}, {self.max_position}]")
         self._start_position = self.current_position
         self._end_position = position
-        dtime = abs(self.end_position - self.start_position) / self.speed
+        dtime = self._move_duration()
         self._end_time = time.monotonic() + dtime
 
     @property
@@ -132,3 +132,8 @@ class PointToPointActuator:
             return 0
 
         return rem_time
+
+    def _move_duration(self):
+        """Compute the total duration of a move, in seconds.
+        """
+        return abs(self.end_position - self.start_position) / self.speed

--- a/python/lsst/ts/simactuators/tracking_actuator.py
+++ b/python/lsst/ts/simactuators/tracking_actuator.py
@@ -48,10 +48,10 @@ class TrackingActuator:
         `set_target`, but not much more than that.
     nsettle : `int` (optional)
         Number of calls to `set_target` after a slew finishes
-        (meaning ``self.current.kind`` is tracking)
+        (meaning ``self.path.kind`` is tracking)
         before ``self.kind(tai)`` reports tracking instead of slewing.
     tai : `float` (optional)
-        TAI time for ``self.target`` and ``self.current``
+        TAI time for ``self.target`` and ``self.path``
         (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
         If None then use current TAI.
         This is primarily for unit tests; None is usually what you want.
@@ -67,7 +67,7 @@ class TrackingActuator:
     Attributes:
 
     * ``target``: target set by `set_target` (a `path.PathSegment`).
-    * ``current``: the current path (a `path.Path`).
+    * ``path``: actual actuator path (a `path.Path`).
     """
     Kind = path.Kind
 
@@ -93,8 +93,8 @@ class TrackingActuator:
         else:
             position = min_position
         self.target = path.PathSegment(tai=tai, position=position)
-        self.current = path.Path(path.PathSegment(tai=tai, position=position),
-                                 kind=self.Kind.Stopped)
+        self.path = path.Path(path.PathSegment(tai=tai, position=position),
+                              kind=self.Kind.Stopped)
         self._ntrack = 0
 
     def set_target(self, tai, position, velocity):
@@ -136,7 +136,7 @@ class TrackingActuator:
             raise ValueError(f"New tai = {tai} <= previous target tai = {prev_tai}")
         if dt < self.dtmax_track:
             # Try tracking.
-            prev_segment = self.current.at(prev_tai)
+            prev_segment = self.path.at(prev_tai)
             tracking_segment = path.PathSegment.from_end_conditions(
                 start_tai=prev_tai,
                 start_position=prev_segment.position,
@@ -154,7 +154,7 @@ class TrackingActuator:
 
         if newcurr is None:
             # Tracking didn't work, so slew.
-            curr_segment = self.current.at(tai)
+            curr_segment = self.path.at(tai)
             newcurr = path.slew(tai=tai,
                                 start_position=curr_segment.position,
                                 start_velocity=curr_segment.velocity,
@@ -163,17 +163,17 @@ class TrackingActuator:
                                 max_velocity=self.max_velocity,
                                 max_acceleration=self.max_acceleration)
         self.target = path.PathSegment(tai=tai, position=position, velocity=velocity)
-        self.current = newcurr
+        self.path = newcurr
 
     @property
-    def current(self):
-        """Get or set the current path, a `path.Path`."""
-        return self._curr
+    def path(self):
+        """Get or set the actuator path, a `path.Path`."""
+        return self._path
 
-    @current.setter
-    def current(self, current):
-        self._curr = current
-        if current.kind == self.Kind.Tracking:
+    @path.setter
+    def path(self, path):
+        self._path = path
+        if path.kind == self.Kind.Tracking:
             self._ntrack += 1
         else:
             self._ntrack = 0
@@ -186,17 +186,19 @@ class TrackingActuator:
         Parameters
         ----------
         tai : `float` (optional)
-            TAI time for ``self.target`` and ``self.current``
+            TAI time for ``self.target`` and ``self.path``
             (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
             If None then use current TAI.
             This is primarily for unit tests; None is usually what you want.
         """
         if tai is None:
             tai = salobj.current_tai()
-        curr_segment = self.current.at(tai)
-        self.current = path.stop(position=curr_segment.position, velocity=curr_segment.velocity, tai=tai,
-                                 max_acceleration=self.max_acceleration)
-        self.target = self.current[-1]
+        curr_segment = self.path.at(tai)
+        self.path = path.stop(tai=tai,
+                              position=curr_segment.position,
+                              velocity=curr_segment.velocity,
+                              max_acceleration=self.max_acceleration)
+        self.target = self.path[-1]
 
     def abort(self, tai=None, position=None):
         """Stop motion immediately, with infinite acceleration.
@@ -206,7 +208,7 @@ class TrackingActuator:
         Parameters
         ----------
         tai : `float` (optional)
-            TAI time for ``self.target`` and ``self.current``
+            TAI time for ``self.target`` and ``self.path``
             (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
             If None then use current TAI.
             This is primarily for unit tests; None is usually what you want.
@@ -217,8 +219,9 @@ class TrackingActuator:
         if tai is None:
             tai = salobj.current_tai()
         if position is None:
-            position = self.current.at(tai).position
-        self.current = path.Path(path.PathSegment(tai=tai, position=position), kind=self.Kind.Stopped)
+            position = self.path.at(tai).position
+        self.path = path.Path(path.PathSegment(tai=tai, position=position),
+                              kind=self.Kind.Stopped)
 
     def kind(self, tai=None):
         """Kind of path at the specified time.
@@ -231,20 +234,20 @@ class TrackingActuator:
             If None then use current TAI.
             Ignored unless stopping.
 
-        The result will always match ``self.current.kind`` except as follows:
+        The result will always match ``self.path.kind`` except as follows:
 
         - After a slew we report ``path.kind.Slewing`` until ``nsettle``
           consecutive calls to `set_target` result in a path that is tracking.
-        - If self.current.kind is stopping and tai > start time of the
+        - If self.path.kind is stopping and tai > start time of the
           last segment, then the kind is reported as stopped.
         """
         if tai is None:
             tai = salobj.current_tai()
-        if self.current.kind == self.Kind.Tracking:
+        if self.path.kind == self.Kind.Tracking:
             if self._ntrack > self.nsettle:
                 return self.Kind.Tracking
             else:
                 return self.Kind.Slewing
-        elif self.current.kind == self.Kind.Stopping and tai > self.current[-1].tai:
+        elif self.path.kind == self.Kind.Stopping and tai > self.path[-1].tai:
             return self.Kind.Stopped
-        return self.current.kind
+        return self.path.kind

--- a/python/lsst/ts/simactuators/tracking_actuator.py
+++ b/python/lsst/ts/simactuators/tracking_actuator.py
@@ -89,15 +89,15 @@ class TrackingActuator:
         if tai is None:
             tai = salobj.current_tai()
         if min_position <= 0 and 0 < max_position:
-            pos = 0
+            position = 0
         else:
-            pos = min_position
-        self.target = path.PathSegment(tai=tai, pos=pos)
-        self.current = path.Path(path.PathSegment(tai=tai, pos=pos),
+            position = min_position
+        self.target = path.PathSegment(tai=tai, position=position)
+        self.current = path.Path(path.PathSegment(tai=tai, position=position),
                                  kind=self.Kind.Stopped)
         self._ntrack = 0
 
-    def set_target(self, tai, pos, vel):
+    def set_target(self, tai, position, velocity):
         """Set the target position, velocity and time.
 
         The actuator will track, if possible, else slew to match the specified
@@ -107,9 +107,9 @@ class TrackingActuator:
         ----------
         tai : `float`
             TAI time (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
-        pos : `float`
+        position : `float`
             Position (deg)
-        vel : `float`
+        velocity : `float`
             Velocity (deg/sec)
 
         Raises
@@ -139,26 +139,30 @@ class TrackingActuator:
             prev_segment = self.current.at(prev_tai)
             tracking_segment = path.PathSegment.from_end_conditions(
                 start_tai=prev_tai,
-                start_position=prev_segment.pos,
-                start_velocity=prev_segment.vel,
+                start_position=prev_segment.position,
+                start_velocity=prev_segment.velocity,
                 end_tai=tai,
-                end_position=pos,
-                end_velocity=vel)
+                end_position=position,
+                end_velocity=velocity)
             limits = tracking_segment.limits(tai)
             if limits.max_velocity <= self.max_velocity and limits.max_acceleration <= self.max_acceleration \
                     and limits.min_position >= self.min_position and limits.max_position <= self.max_position:
                 # Tracking works.
                 newcurr = path.Path(tracking_segment,
-                                    path.PathSegment(tai=tai, pos=pos, vel=vel),
+                                    path.PathSegment(tai=tai, position=position, velocity=velocity),
                                     kind=self.Kind.Tracking)
 
         if newcurr is None:
             # Tracking didn't work, so slew.
             curr_segment = self.current.at(tai)
-            newcurr = path.slew(tai=tai, start_position=curr_segment.pos, start_velocity=curr_segment.vel,
-                                end_position=pos, end_velocity=vel,
-                                max_velocity=self.max_velocity, max_acceleration=self.max_acceleration)
-        self.target = path.PathSegment(tai=tai, pos=pos, vel=vel)
+            newcurr = path.slew(tai=tai,
+                                start_position=curr_segment.position,
+                                start_velocity=curr_segment.velocity,
+                                end_position=position,
+                                end_velocity=velocity,
+                                max_velocity=self.max_velocity,
+                                max_acceleration=self.max_acceleration)
+        self.target = path.PathSegment(tai=tai, position=position, velocity=velocity)
         self.current = newcurr
 
     @property
@@ -190,11 +194,11 @@ class TrackingActuator:
         if tai is None:
             tai = salobj.current_tai()
         curr_segment = self.current.at(tai)
-        self.current = path.stop(pos=curr_segment.pos, vel=curr_segment.vel, tai=tai,
+        self.current = path.stop(position=curr_segment.position, velocity=curr_segment.velocity, tai=tai,
                                  max_acceleration=self.max_acceleration)
         self.target = self.current[-1]
 
-    def abort(self, tai=None, pos=None):
+    def abort(self, tai=None, position=None):
         """Stop motion immediately, with infinite acceleration.
 
         Do not change the commanded position.
@@ -206,15 +210,15 @@ class TrackingActuator:
             (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
             If None then use current TAI.
             This is primarily for unit tests; None is usually what you want.
-        pos : `float` (optional)
+        position : `float` (optional)
             Position at which to stop (deg); if `None` then stop at position
             at time ``tai``.
         """
         if tai is None:
             tai = salobj.current_tai()
-        if pos is None:
-            pos = self.current.at(tai).pos
-        self.current = path.Path(path.PathSegment(tai=tai, pos=pos), kind=self.Kind.Stopped)
+        if position is None:
+            position = self.current.at(tai).position
+        self.current = path.Path(path.PathSegment(tai=tai, position=position), kind=self.Kind.Stopped)
 
     def kind(self, tai=None):
         """Kind of path at the specified time.

--- a/python/lsst/ts/simactuators/tracking_actuator.py
+++ b/python/lsst/ts/simactuators/tracking_actuator.py
@@ -52,7 +52,7 @@ class TrackingActuator:
         before ``self.kind(tai)`` reports tracking instead of slewing.
     tai : `float` (optional)
         TAI time for ``self.target`` and ``self.path``
-        (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
+        (unix seconds, e.g. from lsst.ts.salobj.current_tai()).
         If None then use current TAI.
         This is primarily for unit tests; None is usually what you want.
 
@@ -106,7 +106,7 @@ class TrackingActuator:
         Parameters
         ----------
         tai : `float`
-            TAI time (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
+            TAI time (unix seconds, e.g. from lsst.ts.salobj.current_tai()).
         position : `float`
             Position (deg)
         velocity : `float`
@@ -187,7 +187,7 @@ class TrackingActuator:
         ----------
         tai : `float` (optional)
             TAI time for ``self.target`` and ``self.path``
-            (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
+            (unix seconds, e.g. from lsst.ts.salobj.current_tai()).
             If None then use current TAI.
             This is primarily for unit tests; None is usually what you want.
         """
@@ -209,7 +209,7 @@ class TrackingActuator:
         ----------
         tai : `float` (optional)
             TAI time for ``self.target`` and ``self.path``
-            (unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
+            (unix seconds, e.g. from lsst.ts.salobj.current_tai()).
             If None then use current TAI.
             This is primarily for unit tests; None is usually what you want.
         position : `float` (optional)
@@ -230,7 +230,7 @@ class TrackingActuator:
         ----------
         tai : `float` (optional)
             TAI time at which to evaluate the kind of path
-            (TAI unix seconds, e.g. from lsst.ts.salobj.curr_tai()).
+            (TAI unix seconds, e.g. from lsst.ts.salobj.current_tai()).
             If None then use current TAI.
             Ignored unless stopping.
 

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -43,18 +43,18 @@ class TestPathSegment(unittest.TestCase):
             end_position=end_position,
             end_velocity=end_velocity)
         self.assertAlmostEqual(segment.tai, start_tai)
-        self.assertAlmostEqual(segment.pos, start_position)
-        self.assertAlmostEqual(segment.vel, start_velocity)
+        self.assertAlmostEqual(segment.position, start_position)
+        self.assertAlmostEqual(segment.velocity, start_velocity)
 
-        pva_end = segment.at(end_tai)
-        self.assertAlmostEqual(pva_end.pos, end_position)
-        self.assertAlmostEqual(pva_end.vel, end_velocity)
-        start_accel = segment.accel
+        end_segment = segment.at(end_tai)
+        self.assertAlmostEqual(end_segment.position, end_position)
+        self.assertAlmostEqual(end_segment.velocity, end_velocity)
+        start_accel = segment.acceleration
         jerk = segment.jerk
         desired_end_position = start_position + dt*(start_velocity + dt*(0.5*start_accel + dt*(1/6)*jerk))
         desired_end_velocity = start_velocity + dt*(start_accel + dt*0.5*jerk)
-        self.assertAlmostEqual(pva_end.pos, desired_end_position)
-        self.assertAlmostEqual(pva_end.vel, desired_end_velocity)
+        self.assertAlmostEqual(end_segment.position, desired_end_position)
+        self.assertAlmostEqual(end_segment.velocity, desired_end_velocity)
 
         # estimate position and velocity limits by computing at many points
         desired_min_position = min(start_position, end_position)
@@ -96,23 +96,27 @@ class TestPathSegment(unittest.TestCase):
 
     def test_basics(self):
         tai = 1573847242.4
-        pos = 5.1
-        vel = 4.3
-        accel = 0.23
+        position = 5.1
+        velocity = 4.3
+        acceleration = 0.23
         jerk = 0.05
-        segment = simactuators.path.PathSegment(tai=tai, pos=pos, vel=vel, accel=accel, jerk=jerk)
+        segment = simactuators.path.PathSegment(tai=tai,
+                                                position=position,
+                                                velocity=velocity,
+                                                acceleration=acceleration,
+                                                jerk=jerk)
         self.assertEqual(segment.tai, tai)
-        self.assertEqual(segment.pos, pos)
-        self.assertEqual(segment.vel, vel)
-        self.assertEqual(segment.accel, accel)
+        self.assertEqual(segment.position, position)
+        self.assertEqual(segment.velocity, velocity)
+        self.assertEqual(segment.acceleration, acceleration)
         self.assertEqual(segment.jerk, jerk)
 
         # The at command at the same time should return a copy
         copied_segment = segment.at(tai)
         self.assertEqual(copied_segment.tai, tai)
-        self.assertAlmostEqual(copied_segment.pos, pos)
-        self.assertAlmostEqual(copied_segment.vel, vel)
-        self.assertAlmostEqual(copied_segment.accel, accel)
+        self.assertAlmostEqual(copied_segment.position, position)
+        self.assertAlmostEqual(copied_segment.velocity, velocity)
+        self.assertAlmostEqual(copied_segment.acceleration, acceleration)
         self.assertEqual(copied_segment.jerk, jerk)
 
         for dt in (-5.1, -3.23, 1.23, 6.6):
@@ -123,13 +127,13 @@ class TestPathSegment(unittest.TestCase):
                 # `PathSegment` (to avoid an exact copy),
                 # so the computed values will be slightly different,
                 # especially position and to a lessar extent velocity.
-                expected_pos = pos + vel*dt + accel*dt*dt/2 + jerk*dt*dt*dt/6
-                expected_vel = vel + accel*dt + jerk*dt*dt/2
-                expected_accel = accel + jerk*dt
+                expected_pos = position + velocity*dt + acceleration*dt*dt/2 + jerk*dt*dt*dt/6
+                expected_vel = velocity + acceleration*dt + jerk*dt*dt/2
+                expected_accel = acceleration + jerk*dt
                 self.assertEqual(new_segment.tai, new_tai)
-                self.assertAlmostEqual(new_segment.pos, expected_pos, places=5)
-                self.assertAlmostEqual(new_segment.vel, expected_vel, places=6)
-                self.assertAlmostEqual(new_segment.accel, expected_accel)
+                self.assertAlmostEqual(new_segment.position, expected_pos, places=5)
+                self.assertAlmostEqual(new_segment.velocity, expected_vel, places=6)
+                self.assertAlmostEqual(new_segment.acceleration, expected_accel)
                 self.assertEqual(new_segment.jerk, jerk)
 
     def test_default_arguments(self):
@@ -137,9 +141,9 @@ class TestPathSegment(unittest.TestCase):
         """
         full_kwargs = dict(
             tai=1573847242.4,
-            pos=5.1,
-            vel=4.3,
-            accel=0.23,
+            position=5.1,
+            velocity=4.3,
+            acceleration=0.23,
             jerk=0.05,
         )
         for field_to_omit in full_kwargs:

--- a/tests/test_slew.py
+++ b/tests/test_slew.py
@@ -64,22 +64,22 @@ class TestSlew(unittest.TestCase):
         - The final position and velocity are correct.
         """
         self.assertAlmostEqual(path[0].tai, tai)
-        self.assertAlmostEqual(path[0].pos, start_position)
-        self.assertAlmostEqual(path[0].vel, start_velocity)
+        self.assertAlmostEqual(path[0].position, start_position)
+        self.assertAlmostEqual(path[0].velocity, start_velocity)
 
         for i in range(len(path) - 1):
             segment0 = path[i]
             segment1 = path[i+1]
             dt = segment1.tai - segment0.tai
             self.assertGreater(dt, 0)
-            pred_p1 = segment0.pos + dt*(segment0.vel + dt*0.5*segment0.accel)
-            pred_v1 = segment0.vel + dt*segment0.accel
-            self.assertAlmostEqual(segment1.pos, pred_p1, places=4)
-            self.assertAlmostEqual(segment1.vel, pred_v1, places=4)
+            pred_p1 = segment0.position + dt*(segment0.velocity + dt*0.5*segment0.acceleration)
+            pred_v1 = segment0.velocity + dt*segment0.acceleration
+            self.assertAlmostEqual(segment1.position, pred_p1, places=4)
+            self.assertAlmostEqual(segment1.velocity, pred_v1, places=4)
 
-        for tpvaj in path:
-            self.assertLessEqual(abs(tpvaj.vel), max_velocity)
-            self.assertLessEqual(abs(tpvaj.accel), max_acceleration)
+        for segment in path:
+            self.assertLessEqual(abs(segment.velocity), max_velocity)
+            self.assertLessEqual(abs(segment.acceleration), max_acceleration)
 
     def test_no_slew(self):
         """Test moving from a point to itself (no slew needed)."""
@@ -110,7 +110,7 @@ class TestSlew(unittest.TestCase):
                                 max_velocity=max_velocity,
                                 max_acceleration=max_acceleration)
                 self.assertEqual(len(path), 1)
-                self.assertAlmostEqual(path[0].accel, 0)
+                self.assertAlmostEqual(path[0].acceleration, 0)
 
     def test_long_fixed_points(self):
         """Test a fixed point to fixed point slew that is long enough
@@ -149,35 +149,35 @@ class TestSlew(unittest.TestCase):
 
                 self.assertEqual(len(path), 4)
                 self.assertAlmostEqual(path[0].tai, tai)
-                self.assertAlmostEqual(path[0].pos, start_position)
-                self.assertAlmostEqual(path[0].vel, 0)
-                self.assertAlmostEqual(path[0].accel, math.copysign(max_acceleration, dpos))
+                self.assertAlmostEqual(path[0].position, start_position)
+                self.assertAlmostEqual(path[0].velocity, 0)
+                self.assertAlmostEqual(path[0].acceleration, math.copysign(max_acceleration, dpos))
 
                 predicted_dt1 = dt_max_velocity
                 predicted_t1 = tai + predicted_dt1
                 predicted_dp1 = math.copysign(dp_max_velocity, dpos)
                 predicted_p1 = start_position + predicted_dp1
                 self.assertAlmostEqual(path[1].tai, predicted_t1, places=4)
-                self.assertAlmostEqual(path[1].pos, predicted_p1)
-                self.assertAlmostEqual(abs(path[1].vel), max_velocity)
-                self.assertAlmostEqual(path[1].accel, 0)
+                self.assertAlmostEqual(path[1].position, predicted_p1)
+                self.assertAlmostEqual(abs(path[1].velocity), max_velocity)
+                self.assertAlmostEqual(path[1].acceleration, 0)
 
                 predicted_abs_dp2 = abs(dpos) - 2*dp_max_velocity
                 predicted_dp2 = math.copysign(predicted_abs_dp2, dpos)
-                predicted_p2 = path[1].pos + predicted_dp2
+                predicted_p2 = path[1].position + predicted_dp2
                 predicted_dt2 = abs(predicted_dp2)/max_velocity
                 predicted_t2 = path[1].tai + predicted_dt2
                 self.assertAlmostEqual(path[2].tai, predicted_t2, places=4)
-                self.assertAlmostEqual(path[2].pos, predicted_p2)
-                self.assertAlmostEqual(abs(path[2].vel), max_velocity)
-                self.assertAlmostEqual(path[2].accel, -path[0].accel)
+                self.assertAlmostEqual(path[2].position, predicted_p2)
+                self.assertAlmostEqual(abs(path[2].velocity), max_velocity)
+                self.assertAlmostEqual(path[2].acceleration, -path[0].acceleration)
 
                 predicted_duration = 2*dt_max_velocity + predicted_dt2
                 predicted_t3 = tai + predicted_duration
                 self.assertAlmostEqual(path[3].tai, predicted_t3, places=4)
-                self.assertAlmostEqual(path[3].pos, end_position)
-                self.assertAlmostEqual(path[3].vel, 0)
-                self.assertAlmostEqual(path[3].accel, 0)
+                self.assertAlmostEqual(path[3].position, end_position)
+                self.assertAlmostEqual(path[3].velocity, 0)
+                self.assertAlmostEqual(path[3].acceleration, 0)
 
     def test_short_fixed_points(self):
         """Test a fixed point to fixed point slew that is long enough
@@ -215,24 +215,24 @@ class TestSlew(unittest.TestCase):
 
                 self.assertEqual(len(path), 3)
                 self.assertAlmostEqual(path[0].tai, tai)
-                self.assertAlmostEqual(path[0].pos, start_position)
-                self.assertAlmostEqual(path[0].vel, 0)
-                self.assertAlmostEqual(path[0].accel, math.copysign(max_acceleration, dpos))
+                self.assertAlmostEqual(path[0].position, start_position)
+                self.assertAlmostEqual(path[0].velocity, 0)
+                self.assertAlmostEqual(path[0].acceleration, math.copysign(max_acceleration, dpos))
 
                 predicted_dt1 = math.sqrt(abs(dpos)/max_acceleration)
                 predicted_t1 = tai + predicted_dt1
                 predicted_p1 = start_position + dpos/2
                 predicted_v1 = predicted_dt1*max_acceleration
                 self.assertAlmostEqual(path[1].tai, predicted_t1, places=4)
-                self.assertAlmostEqual(path[1].pos, predicted_p1)
-                self.assertAlmostEqual(abs(path[1].vel), predicted_v1)
-                self.assertAlmostEqual(path[1].accel, -path[0].accel)
+                self.assertAlmostEqual(path[1].position, predicted_p1)
+                self.assertAlmostEqual(abs(path[1].velocity), predicted_v1)
+                self.assertAlmostEqual(path[1].acceleration, -path[0].acceleration)
 
                 predicted_t2 = tai + 2*predicted_dt1
                 self.assertAlmostEqual(path[2].tai, predicted_t2, places=4)
-                self.assertAlmostEqual(path[2].pos, end_position)
-                self.assertAlmostEqual(path[2].vel, 0)
-                self.assertAlmostEqual(path[2].accel, 0)
+                self.assertAlmostEqual(path[2].position, end_position)
+                self.assertAlmostEqual(path[2].velocity, 0)
+                self.assertAlmostEqual(path[2].acceleration, 0)
 
     def test_other_slews(self):
         # Arbitrary but reasonable values


### PR DESCRIPTION
Use "position" instead of "pos", "velocity instead of "vel",
and "acceleration" instead of "accel".
Rename property "direction" to "direction_factor".